### PR TITLE
Add lint and publish workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,42 @@
+name: Python package
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+      - name: Run flake8
+        run: flake8 src setup.py
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Build package
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.8
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
## Summary
- add GitHub Action for lint with flake8
- add publish step for PyPI on tags

## Testing
- `flake8 src setup.py`


------
https://chatgpt.com/codex/tasks/task_e_688bf1d0121c832095abb70c5a61568d

## Summary by Sourcery

Introduce a CI workflow to enforce linting and automate package publishing to PyPI for tagged releases.

CI:
- Add GitHub Actions workflow for linting Python code with flake8 on pushes and pull requests
- Add publish step to build and upload the package to PyPI on version tags