### PR TITLE
Add lint and publish workflow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,6 +35,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install build
           python -m build
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.8
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,42 @@
+name: Python package
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+      - name: Run flake8
+        run: flake8 src setup.py
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Build package
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.8.8
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
## Summary
- add GitHub Action for lint with flake8
- add publish step for PyPI on tags

## Testing
- `flake8 src setup.py`


------
https://chatgpt.com/codex/tasks/task_e_688bf1d0121c832095abb70c5a61568d

## Summary by Sourcery

Add GitHub Actions workflow to lint code with flake8 on pushes and pull requests and to build and publish the package to PyPI on version tags

CI:
- Introduce lint job using flake8 on Python 3.10
- Add conditional publish job to build and upload package to PyPI on tagged releases