### PR TITLE
Add REST speed configuration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,3 +17,5 @@ python -m openapi_servo_control
 ```
 
 Swagger API documentation will be available at `http://localhost:3001/api/docs`.
+The REST API now supports setting and reading the movement speed for each axis using
+`/api/servo/{axis}/speed/{speed}` and `/api/servo/{axis}/speed`.

--- a/src/openapi_servo_control/axis_container.py
+++ b/src/openapi_servo_control/axis_container.py
@@ -27,6 +27,7 @@ class Axis(dict):
         self.name = ''
         self.position = None
         self.velocity = None
+        self.speed = 1
         self.movement = None
         self.tilt_angle = Axis.tilt_angle
 
@@ -35,6 +36,7 @@ class Axis(dict):
         return {
             'name': self.name,
             'velocity': self.velocity,
+            'speed': self.speed,
             'position': self.position,
             'movement': self.movement,
         }
@@ -44,6 +46,7 @@ class Axis(dict):
         return (
             f'Name: "{self.name}", '
             f'Velocity "{self.velocity}", '
+            f'Speed "{self.speed}", '
             f'Position "{self.position}"'
         )
 
@@ -57,6 +60,9 @@ class Axis(dict):
         if self.position is None:
             self.position = 0
         self.movement = None
+
+    def set_speed(self, speed):
+        self.speed = speed
 
     def set_tilt(self, angle=None):
         self.movement = 'TILT'
@@ -81,7 +87,10 @@ class Axis(dict):
         self.move_axis()
 
     def move_axis(self):
-        self.position = self.position + self.velocity
+        step = self.velocity
+        if self.speed is not None:
+            step = self.velocity * self.speed
+        self.position = self.position + step
 
 
 class AxisContainer(object):

--- a/src/openapi_servo_control/data/api.yaml
+++ b/src/openapi_servo_control/data/api.yaml
@@ -97,6 +97,42 @@ paths:
       responses:
         '200':
           description: Velocity set
+  /servo/{axis}/speed/{speed}:
+    post:
+      summary: Sets the speed for the axis
+      tags:
+      - servo
+      parameters:
+      - name: axis
+        default: 0
+        in: path
+        required: true
+        type: number
+        description: Axis number
+      - name: speed
+        default: 0
+        in: path
+        required: true
+        type: number
+        description: Movement speed
+      responses:
+        '200':
+          description: Speed set
+  /servo/{axis}/speed:
+    get:
+      summary: Gets the speed for the axis
+      tags:
+      - servo
+      parameters:
+      - name: axis
+        default: 0
+        in: path
+        required: true
+        type: number
+        description: Axis number
+      responses:
+        '200':
+          description: Current speed
   /servo/{axis}/status:
     get:
       summary: Gets the status for the axis

--- a/src/openapi_servo_control/http_service.py
+++ b/src/openapi_servo_control/http_service.py
@@ -37,6 +37,16 @@ class HttpService:
         )
         self.app.router.add_route(
             'POST',
+            r'/api/servo/{axis:\d+}/speed/{speed:-?\d+}',
+            self.set_speed,
+        )
+        self.app.router.add_route(
+            'GET',
+            r'/api/servo/{axis:\d+}/speed',
+            self.get_speed,
+        )
+        self.app.router.add_route(
+            'POST',
             r'/api/servo/{axis:\d+}/tilt',
             self.set_tilt,
         )
@@ -166,6 +176,18 @@ class HttpService:
             {'status': 200, 'message': 'Request executed'}
         )
 
+    async def set_speed(self, request):
+        '''
+        ---
+        Sets the speed for the required axis
+        '''
+        axis_id = int(request.match_info['axis'])
+        speed = int(request.match_info['speed'])
+        self.axis_container.axises.get(axis_id).set_speed(speed)
+        return web.json_response(
+            {'status': 200, 'message': 'Request executed'}
+        )
+
     async def set_tilt(self, request):
         '''
         ---
@@ -192,6 +214,15 @@ class HttpService:
         return web.json_response(
             {'status': 200, 'message': 'Request executed'}
         )
+
+    async def get_speed(self, request):
+        '''
+        ---
+        Returns current speed for the required axis
+        '''
+        axis_id = int(request.match_info['axis'])
+        speed = self.axis_container.axises.get(axis_id).speed
+        return web.json_response({'speed': speed})
 
     async def get_status(self, request):
         '''


### PR DESCRIPTION
## Summary
- allow setting per-axis speed
- expose `/api/servo/{axis}/speed` endpoints in the web service
- export the speed value via status JSON
- document speed API in README and swagger spec

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c5d6e700c8320b98fa7bfca47f45e

## Summary by Sourcery

Add per-axis speed configuration by introducing a speed property on axes, updating movement logic to factor in speed, and exposing new REST endpoints to set and get speed while updating documentation and status output.

New Features:
- Introduce a speed property on each axis and apply it as a multiplier in movement calculations
- Add POST /api/servo/{axis}/speed/{speed} and GET /api/servo/{axis}/speed endpoints to set and retrieve axis speed
- Expose current speed in the axis status JSON response

Documentation:
- Document the new speed API in the README and update the OpenAPI (Swagger) specification