### PR TITLE
Add swing endpoint with configurable angle

### DIFF
--- a/src/openapi_servo_control/axis_container.py
+++ b/src/openapi_servo_control/axis_container.py
@@ -64,9 +64,11 @@ class Axis(dict):
         if angle is not None:
             self.tilt_angle = angle
 
-    def set_swing(self):
+    def set_swing(self, angle=None):
         self.movement = 'SWING'
         self.position = Axis.tilt_base
+        if angle is not None:
+            self.tilt_angle = angle
         self.velocity = 1
 
     def tilt_axis(self):
@@ -74,9 +76,9 @@ class Axis(dict):
             round(self.tilt_angle * random.random())
 
     def swing_axis(self):
-        if (self.position > Axis.tilt_base + Axis.tilt_angle / 2):
+        if (self.position > Axis.tilt_base + self.tilt_angle / 2):
             self.velocity = -1
-        elif (self.position < Axis.tilt_base - Axis.tilt_angle / 2):
+        elif (self.position < Axis.tilt_base - self.tilt_angle / 2):
             self.velocity = 1
         self.move_axis()
 

--- a/src/openapi_servo_control/data/api.yaml
+++ b/src/openapi_servo_control/data/api.yaml
@@ -14,13 +14,13 @@ paths:
         default: 0
         in: path
         required: true
-        type: number
+        type: integer
         description: Axis number
       - name: position
         default: 0
         in: path
         required: true
-        type: number
+        type: integer
         description: Rotation angle
       responses:
         '200':
@@ -35,13 +35,13 @@ paths:
         default: 0
         in: path
         required: true
-        type: number
+        type: integer
         description: Axis number
       - name: angle
         default: 0
         in: path
         required: true
-        type: number
+        type: integer
         description: Maximum angle to tilt
       responses:
         '200':
@@ -56,7 +56,7 @@ paths:
         default: 0
         in: path
         required: true
-        type: number
+        type: integer
         description: Axis number
       responses:
         '200':
@@ -71,28 +71,12 @@ paths:
         default: 0
         in: path
         required: true
-        type: number
-        description: Axis number
-      responses:
-        '200':
-          description: Swing enabled
-  /servo/{axis}/swing/{angle}:
-    post:
-      summary: Sets the position for the axis
-      tags:
-      - servo
-      parameters:
-      - name: axis
-        default: 0
-        in: path
-        required: true
-        type: number
+        type: integer
         description: Axis number
       - name: angle
-        default: 0
-        in: path
-        required: true
-        type: number
+        in: query
+        required: false
+        type: integer
         description: Maximum angle to swing
       responses:
         '200':
@@ -107,13 +91,13 @@ paths:
         default: 0
         in: path
         required: true
-        type: number
+        type: integer
         description: Axis number
       - name: velocity
         default: 0
         in: path
         required: true
-        type: number
+        type: integer
         description: Rotation velocity
       responses:
         '200':
@@ -128,7 +112,7 @@ paths:
         default: 0
         in: path
         required: true
-        type: number
+        type: integer
         description: Axis number
       responses:
         '200':

--- a/src/openapi_servo_control/data/api.yaml
+++ b/src/openapi_servo_control/data/api.yaml
@@ -76,6 +76,27 @@ paths:
       responses:
         '200':
           description: Swing enabled
+  /servo/{axis}/swing/{angle}:
+    post:
+      summary: Sets the position for the axis
+      tags:
+      - servo
+      parameters:
+      - name: axis
+        default: 0
+        in: path
+        required: true
+        type: number
+        description: Axis number
+      - name: angle
+        default: 0
+        in: path
+        required: true
+        type: number
+        description: Maximum angle to swing
+      responses:
+        '200':
+          description: Swing enabled
   /servo/{axis}/velocity/{velocity}:
     post:
       summary: Sets the velocity for the axis

--- a/src/openapi_servo_control/http_service.py
+++ b/src/openapi_servo_control/http_service.py
@@ -199,7 +199,9 @@ class HttpService:
             except ValueError:
                 raise web.HTTPBadRequest(text='Angle must be integer')
             if angle < 0 or angle > 180:
-                raise web.HTTPBadRequest(text='Angle must be between 0 and 180')
+                raise web.HTTPBadRequest(
+                    text='Angle must be between 0 and 180'
+                )
             axis.set_swing(angle)
         else:
             axis.set_swing()

--- a/src/openapi_servo_control/http_service.py
+++ b/src/openapi_servo_control/http_service.py
@@ -51,11 +51,6 @@ class HttpService:
             self.set_swing,
         )
         self.app.router.add_route(
-            'POST',
-            r'/api/servo/{axis:\d+}/swing/{angle:\d+}',
-            self.set_swing,
-        )
-        self.app.router.add_route(
             'GET',
             r'/api/servo/{axis:\d+}/status',
             self.get_axis_status,
@@ -193,11 +188,21 @@ class HttpService:
         Starts swing for the required axis
         '''
         axis_id = int(request.match_info['axis'])
-        angle = int(request.match_info.get('angle', Axis.tilt_angle))
-        if 'angle' in request.match_info:
-            self.axis_container.axises.get(axis_id).set_swing(angle)
+        axis = self.axis_container.axises.get(axis_id)
+        if axis is None:
+            raise web.HTTPNotFound(text='Axis not found')
+
+        angle_param = request.rel_url.query.get('angle')
+        if angle_param is not None:
+            try:
+                angle = int(angle_param)
+            except ValueError:
+                raise web.HTTPBadRequest(text='Angle must be integer')
+            if angle < 0 or angle > 180:
+                raise web.HTTPBadRequest(text='Angle must be between 0 and 180')
+            axis.set_swing(angle)
         else:
-            self.axis_container.axises.get(axis_id).set_swing()
+            axis.set_swing()
         return web.json_response(
             {'status': 200, 'message': 'Request executed'}
         )

--- a/src/openapi_servo_control/http_service.py
+++ b/src/openapi_servo_control/http_service.py
@@ -51,6 +51,11 @@ class HttpService:
             self.set_swing,
         )
         self.app.router.add_route(
+            'POST',
+            r'/api/servo/{axis:\d+}/swing/{angle:\d+}',
+            self.set_swing,
+        )
+        self.app.router.add_route(
             'GET',
             r'/api/servo/{axis:\d+}/status',
             self.get_axis_status,
@@ -188,7 +193,11 @@ class HttpService:
         Starts swing for the required axis
         '''
         axis_id = int(request.match_info['axis'])
-        self.axis_container.axises.get(axis_id).set_swing()
+        angle = int(request.match_info.get('angle', Axis.tilt_angle))
+        if 'angle' in request.match_info:
+            self.axis_container.axises.get(axis_id).set_swing(angle)
+        else:
+            self.axis_container.axises.get(axis_id).set_swing()
         return web.json_response(
             {'status': 200, 'message': 'Request executed'}
         )


### PR DESCRIPTION
## Summary
- allow configuring swing angle for individual axis
- add new endpoint to HTTP service
- document swing angle endpoint in OpenAPI spec

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c6df054fc8320a2ba598d0dd2beba

## Summary by Sourcery

Introduce per-axis configurable swing angles by adding a new HTTP endpoint and updating axis logic to support and use instance-specific tilt parameters.

New Features:
- Add POST /servo/{axis}/swing/{angle} endpoint to configure swing angle per axis

Enhancements:
- Allow the swing handler to accept an optional angle parameter and pass it to Axis.set_swing
- Store and use instance-level tilt_angle in swing logic instead of a static class constant

Documentation:
- Document the configurable swing angle endpoint in the OpenAPI spec