### PR TITLE
Add API to control update delay

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,3 +17,9 @@ python -m openapi_servo_control
 ```
 
 Swagger API documentation will be available at `http://localhost:3001/api/docs`.
+
+To change the update delay for axes positions call:
+
+```bash
+curl -X POST http://localhost:3001/api/servo/delay/0.2
+```

--- a/src/openapi_servo_control/__init__.py
+++ b/src/openapi_servo_control/__init__.py
@@ -16,7 +16,7 @@ def main():
     loop = asyncio.get_event_loop()
     axis = AxisContainer(15)
     servo_controler = Servocontroller(axis)
-    http_service = HttpService(axis)
+    http_service = HttpService(axis, servo_controler)
     signals = [signal.SIGHUP, signal.SIGTERM, signal.SIGINT]
 
     async def kill_loop():

--- a/src/openapi_servo_control/data/api.yaml
+++ b/src/openapi_servo_control/data/api.yaml
@@ -120,3 +120,17 @@ paths:
       responses:
         '200':
           description: Status for the entire system
+  /servo/delay/{delay}:
+    post:
+      summary: Sets delay between coordinate updates
+      tags:
+      - servo
+      parameters:
+      - name: delay
+        in: path
+        required: true
+        type: number
+        description: Delay in seconds
+      responses:
+        '200':
+          description: Delay set

--- a/src/openapi_servo_control/http_service.py
+++ b/src/openapi_servo_control/http_service.py
@@ -21,10 +21,11 @@ class HttpService:
     server
     '''
 
-    def __init__(self, axis_container: AxisContainer):
+    def __init__(self, axis_container: AxisContainer, servo_controller):
         self.app = web.Application()
         self.runner = None
         self.axis_container = axis_container
+        self.servo_controller = servo_controller
         self.app.router.add_route(
             'POST',
             r'/api/servo/{axis:\d+}/position/{position:-?\d+}',
@@ -59,6 +60,11 @@ class HttpService:
             'GET',
             '/api/servo/status',
             self.get_status,
+        )
+        self.app.router.add_route(
+            'POST',
+            r'/api/servo/delay/{delay:?-?\d+(\.\d+)?}',
+            self.set_delay,
         )
         swagger_file = os.path.join(
             os.path.dirname(__file__), '../../data/api.yaml')
@@ -189,6 +195,17 @@ class HttpService:
         '''
         axis_id = int(request.match_info['axis'])
         self.axis_container.axises.get(axis_id).set_swing()
+        return web.json_response(
+            {'status': 200, 'message': 'Request executed'}
+        )
+
+    async def set_delay(self, request):
+        '''
+        ---
+        Sets delay between coordinate updates
+        '''
+        delay = request.match_info['delay']
+        self.servo_controller.set_delay(delay)
         return web.json_response(
             {'status': 200, 'message': 'Request executed'}
         )

--- a/src/openapi_servo_control/servo_controller.py
+++ b/src/openapi_servo_control/servo_controller.py
@@ -30,6 +30,7 @@ class Servocontroller(object):
         self.pwm.set_pwm_freq(Servocontroller.frequency)
         self.started = False
         self.axis_container = axis_container
+        self.update_delay = 0.1
 
     async def start(self):
         self.started = True
@@ -50,7 +51,14 @@ class Servocontroller(object):
                     ) + 110
                     self.pwm.set_pwm(key, 0, pulse_len)
                     # logger.debug(self.axis_container.axises.get(key))
-            await asyncio.sleep(.1)
+            await asyncio.sleep(self.update_delay)
 
     def stop(self):
         self.started = False
+
+    def set_delay(self, delay: float):
+        """Set update delay between coordinate refreshes."""
+        try:
+            self.update_delay = float(delay)
+        except (ValueError, TypeError):
+            logger.warning('Incorrect delay value: %s', delay)


### PR DESCRIPTION
## Summary
- allow ServoController delay to be changed at runtime
- expose new route `/api/servo/delay/{delay}`
- pass ServoController instance into HttpService
- document delay endpoint

## Testing
- `pip install -e .`
- `python -m py_compile src/openapi_servo_control/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688c71c0a55483209befe46b5da2d09c

## Summary by Sourcery

Enable dynamic configuration of the servo update interval via a new HTTP API endpoint

New Features:
- Add POST /api/servo/delay/{delay} endpoint to adjust the servo update delay at runtime

Enhancements:
- Pass ServoController instance into HttpService to enable delay configuration
- Introduce set_delay method in ServoController for updating the refresh interval

Documentation:
- Update OpenAPI spec and README to document the new delay endpoint