### PR TITLE
Install openssh-client before SSH deploy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Checkout
         if: steps.check.outputs.skip == 'false'
         uses: actions/checkout@v4
+      - name: Install ssh client
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          if ! command -v scp >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends openssh-client
+          fi
       - name: Install uv
         if: steps.check.outputs.skip == 'false'
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
The summerwind/actions-runner image doesn't ship scp/ssh, so the deploy step failed with "scp: command not found". Install it on demand (idempotent: skipped if already present) before shipping the wheel to the Pi.

## Summary by Sourcery

CI:
- Add a conditional step in the CI workflow to install the openssh-client package when scp is not already available.