### PR TITLE
Copy mounted Pi SSH key to a writable path before scp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,18 @@ jobs:
           # pi-ssh-key Secret is mounted at ~/.ssh as root:root 0600 and
           # readOnly, so the runner user can't read it or write known_hosts.
           # Copy the key out with the right perms and use a writable
-          # known_hosts in /tmp for this step.
-          SSH_KEY=/tmp/pi_ssh_key
-          KNOWN_HOSTS=/tmp/pi_known_hosts
+          # known_hosts under /tmp for this step. Use mktemp so repeated
+          # runs on the same runner can't collide on a stale /tmp file.
+          SRC_KEY="$HOME/.ssh/id_ed25519"
+          if ! sudo test -f "$SRC_KEY"; then
+            echo "SSH key not found at $SRC_KEY - is the pi-ssh-key Secret mounted?" >&2
+            exit 1
+          fi
+          SSH_KEY="$(mktemp /tmp/pi_ssh_key.XXXXXX)"
+          KNOWN_HOSTS="$(mktemp /tmp/pi_known_hosts.XXXXXX)"
           sudo install -o "$(id -u)" -g "$(id -g)" -m 0600 \
-              /home/runner/.ssh/id_ed25519 "$SSH_KEY"
-          : > "$KNOWN_HOSTS"
+              "$SRC_KEY" "$SSH_KEY"
+          trap 'rm -f "$SSH_KEY" "$KNOWN_HOSTS"' EXIT
 
           SSH_OPTS=(
             -i "$SSH_KEY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,27 @@ jobs:
           fi
           WHEEL="${wheels[0]}"
           REMOTE_WHEEL="/tmp/$(basename "$WHEEL")"
-          scp -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-              "$WHEEL" "$PI_HOST:$REMOTE_WHEEL"
-          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-              "$PI_HOST" bash -s -- "$REMOTE_WHEEL" <<'EOF'
+
+          # pi-ssh-key Secret is mounted at ~/.ssh as root:root 0600 and
+          # readOnly, so the runner user can't read it or write known_hosts.
+          # Copy the key out with the right perms and use a writable
+          # known_hosts in /tmp for this step.
+          SSH_KEY=/tmp/pi_ssh_key
+          KNOWN_HOSTS=/tmp/pi_known_hosts
+          sudo install -o "$(id -u)" -g "$(id -g)" -m 0600 \
+              /home/runner/.ssh/id_ed25519 "$SSH_KEY"
+          : > "$KNOWN_HOSTS"
+
+          SSH_OPTS=(
+            -i "$SSH_KEY"
+            -o IdentitiesOnly=yes
+            -o StrictHostKeyChecking=accept-new
+            -o UserKnownHostsFile="$KNOWN_HOSTS"
+            -o BatchMode=yes
+          )
+
+          scp "${SSH_OPTS[@]}" "$WHEEL" "$PI_HOST:$REMOTE_WHEEL"
+          ssh "${SSH_OPTS[@]}" "$PI_HOST" bash -s -- "$REMOTE_WHEEL" <<'EOF'
           set -euo pipefail
           WHEEL="$1"
           VENV=/opt/servo-venv


### PR DESCRIPTION
The pi-ssh-key Secret is mounted into the runner pod at /home/runner/.ssh as root:root 0600 readOnly, so the runner user (uid 1001) can't read the key and the SSH client can't write known_hosts either. Use sudo install to copy the key out to /tmp with runner-owned 0600 perms, and point the ssh/scp invocations at a writable UserKnownHostsFile under /tmp.

## Summary by Sourcery

CI:
- Adjust Raspberry Pi deployment workflow to copy the mounted SSH key to /tmp with correct ownership and permissions and use a writable known_hosts file for SSH/SCP connections.