### PR TITLE
Use stock python3 venv + pip on the Pi instead of uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,10 @@ jobs:
           VENV=/opt/servo-venv
           BIN_LINK=/usr/local/bin/openapi-servo-control
           if [ ! -d "$VENV" ]; then
-            sudo uv venv --python python3 "$VENV"
+            sudo python3 -m venv "$VENV"
+            sudo "$VENV/bin/pip" install --upgrade pip
           fi
-          sudo uv pip install --python "$VENV/bin/python" --upgrade "$WHEEL"
+          sudo "$VENV/bin/pip" install --upgrade "$WHEEL"
           sudo ln -sf "$VENV/bin/openapi-servo-control" "$BIN_LINK"
           rm -f "$WHEEL"
           sudo systemctl restart servo-control


### PR DESCRIPTION
uv isn't installed on the Pi (and even if it were, sudo secure_path would hide a ~/.local/bin install). Build the wheel with uv on the runner where it's fast, but on the Pi fall back to python3 -m venv and the venv's own pip - both are part of the stock Python install so no extra provisioning is needed on the target host.

## Summary by Sourcery

CI:
- Adjust CI deployment script to provision the venv with python3 -m venv and install the built wheel using the venv's pip rather than uv.