### PR TITLE
Bootstrap Pi from scratch on first deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           WHEEL="$1"
           VENV=/opt/servo-venv
           BIN_LINK=/usr/local/bin/openapi-servo-control
+          UNIT=servo-control
           if [ ! -d "$VENV" ]; then
             sudo python3 -m venv "$VENV"
             sudo "$VENV/bin/pip" install --upgrade pip
@@ -126,6 +127,12 @@ jobs:
           sudo "$VENV/bin/pip" install --upgrade "$WHEEL"
           sudo ln -sf "$VENV/bin/openapi-servo-control" "$BIN_LINK"
           rm -f "$WHEEL"
-          sudo systemctl restart servo-control
-          sudo systemctl is-active servo-control
+          # Drop api.yaml into /etc/openapi_servo_control and the systemd
+          # unit into /etc/systemd/system. Idempotent: the installer uses
+          # shutil.copy which overwrites on re-run.
+          sudo "$VENV/bin/install-openapi-servo-configs"
+          sudo systemctl daemon-reload
+          sudo systemctl enable "$UNIT"
+          sudo systemctl restart "$UNIT"
+          sudo systemctl is-active "$UNIT"
           EOF


### PR DESCRIPTION
After installing the wheel, run install-openapi-servo-configs to lay down /etc/openapi_servo_control/api.yaml and the servo-control systemd unit, then daemon-reload and enable the unit so a clean Pi ends up with everything wired up after a single deploy. Re-runs are idempotent (the installer overwrites) and daemon-reload picks up any unit changes shipped in the wheel.

## Summary by Sourcery

CI:
- Update deployment script in CI workflow to install OpenAPI servo configs, reload systemd, and enable the servo-control unit instead of only restarting it.